### PR TITLE
Observability: fix null pointer exception iterating over keys

### DIFF
--- a/src/main/java/io/orijtech/integrations/ocspymemcached/Observability.java
+++ b/src/main/java/io/orijtech/integrations/ocspymemcached/Observability.java
@@ -236,8 +236,10 @@ public class Observability {
         MeasureMap measureMap = statsRecorder.newMeasureMap();
 
         // Record the key length if applicable.
-        for (String key : this.keys) {
-          if (key != null) measureMap.put(Observability.MEASURE_LENGTH, key.length());
+        if (this.keys != null) {
+          for (String key : this.keys) {
+            if (key != null) measureMap.put(Observability.MEASURE_LENGTH, key.length());
+          }
         }
 
         // Record the latency.

--- a/src/test/java/io/orijtech/integrations/ocspymemcached/ObservabilityTest.java
+++ b/src/test/java/io/orijtech/integrations/ocspymemcached/ObservabilityTest.java
@@ -226,4 +226,11 @@ public class ObservabilityTest {
     Mockito.verify(mockMeasureMap, Mockito.times(1)).record(any(TagContext.class));
     Mockito.verify(mockSpan, Mockito.times(1)).end();
   }
+
+  @Test
+  public void trackingOperation_operationFutureListener_nullKeysNoPanics() {
+    TrackingOperation trackingOperation =
+        new TrackingOperation("net.spy.memcached.MemcachedClient.foo-with-null-keys");
+    trackingOperation.end();
+  }
 }


### PR DESCRIPTION
There was a case in which if this.keys was null, doing
```java
for (String key : this.keys)
```

would cause a null-pointer exception
```shell
net.spy.memcached.internal.OperationFuture:  Exception thrown wile executing io.orijtech.integrations.ocspymemcached.Observability$OperationFutureCompletionListener.operationComplete()
java.lang.NullPointerException
	at io.orijtech.integrations.ocspymemcached.Observability$TrackingOperation.end(Observability.java:239)
	at io.orijtech.integrations.ocspymemcached.Observability$OperationFutureCompletionListener.onComplete(Observability.java:316)
	at io.orijtech.integrations.ocspymemcached.Observability$OperationFutureCompletionListener.onComplete(Observability.java:303)
	at net.spy.memcached.internal.AbstractListenableFuture$1.run(AbstractListenableFuture.java:117)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.base/java.lang.Thread.run(Thread.java:844)
```

So added a fix for this along with a minimal test case.